### PR TITLE
Примеры установки logger.rootLogger=DEBUG в командной строке

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ set LOGOS_CONFIG=logger.oscript.lib.commands=DEBUG;logger.oscript.lib.cmdline=DE
 
     logger.rootLogger=DEBUG
 
+Обычная установка через командную строку, например, используя отдельный командный файл
+
+    set LOGOS_CONFIG=logger.rootLogger=DEBUG
+
+Установка и немедленный запуск команды-скрипта через командную строку без создания командного файла
+
+    (set LOGOS_CONFIG=logger.rootLogger=DEBUG) && (любая команда)
+    
+    (set LOGOS_CONFIG=logger.rootLogger=DEBUG) && (vanessa-runner help)
+
 ### Настройка способа вывода (класс appender)
 
     logger.oscript.lib.v8runner=DEBUG, v8rdebug, console


### PR DESCRIPTION
по следам https://xdd.silverbulleters.org/t/kak-v-odnoj-komande-sovmestit-ustanovku-peremennoj-sredy-i-zapuska-posleduyushhej-komandy-windows/1783/10